### PR TITLE
iprove API + prepare release

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ var el = d3.select('svg')
 var tipFactory = d3scription(function(d) { return d.desc; });
 
 // create tip for our main group element
-var tip = tipFactory(el);
+var tip = tipFactory()
+    .element(el);
 
 // set data to circles
 var circles = el.selectAll('.circle')
@@ -122,12 +123,12 @@ const el = d3.select('#first-example')
 const tipFactory = d3scription((d : Data) => d.desc);
 
 // create tip for our main group element
-const tip = tipFactory(el);
+const tip = tipFactory()
+    .element(el);
 
 // set data to circles
 const circles = el.selectAll('.circle')
     .data(data);
-
 
 // draw circles
 const cEnter = circles.enter()
@@ -149,7 +150,7 @@ Anyway as you can see writing your own styles for tooltip is really simple.
 # API
 
 Api is design as three steps process to make reuse and flow as clean as possible.
-These steps are `setup` > `initialise` > `use`. Folloving paragraphs describes each step individually.
+These steps are `setup` > `initialize` > `use`. Folloving paragraphs describes each step individually.
 
 ## Setup
 
@@ -202,21 +203,21 @@ You can create many tips from one factory using this function.
 
 ```js
 var element = d3.select('svg').append('g');
-var tip = myD3scription(element); // this function was returned by setup
+var tip = myD3scription().element(element); // this function was returned by setup
 ```
 
 ## Tip
 
 Finally you'll have a tip instance returned by from factory (after passing element).
 Now you can call methods on this tip as you wish. Most common case is to `show(data)` and `hide()`
-on mouse events. you can also take advantage of `setElement(element)` for changing orginal element of tip
+on mouse events. you can also take advantage of `element(element)` for changing orginal element of tip
 or using `destroy()`.
 
 ## Tip API
 
 * `show(data)` sets content of tip and displays it.
 * `hide()` hides tip
-* `setElement(element)` sets new element for tip
+* `element(element)` sets new element for tip
 * `destroy()` removes tip from dom
 
 ## Basic Example of usage
@@ -241,6 +242,7 @@ var cEnter = circles.enter()
 ```
 # Changelog
 
+- v1.0.0 - improve API
 - v0.0.2 - window edge collision detections
 - v0.0.1 - initial release
 

--- a/demo/first.ts
+++ b/demo/first.ts
@@ -23,7 +23,8 @@ const el = d3.select('#first-example')
     .append('g');
 
 const tipFactory = d3scription((d : D) => d.desc);
-const tip = tipFactory(el);
+const tip = tipFactory()
+    .element(el);
 
 const circles = el.selectAll('.circle')
     .data(data);

--- a/demo/second.js
+++ b/demo/second.js
@@ -9,12 +9,14 @@ var data = [
         y: 70*Math.random()+50,
         desc: 'I love it!'
     }
-]
+];
+
 var el = d3.select('#second-example')
     .append('g');
 
 var tipFactory = d3scription(function(d) { return d.desc; });
-var tip = tipFactory(el);
+var tip = tipFactory()
+    .element(el);
 
 var circles = el.selectAll('.circle')
     .data(data);

--- a/dist/d3scription.js
+++ b/dist/d3scription.js
@@ -86,7 +86,7 @@ var d3scription = d3scription || {}; d3scription["d3scription"] =
 	    function d3scription(contentGetter, options) {
 	        if (options === void 0) { options = {}; }
 	        var offsetSettings = getOffsetSettings(options.offset);
-	        return function (element) {
+	        return function () {
 	            var tip = d3.select('body')
 	                .append('div')
 	                .attr('class', options.class || 'd3scription-tip')
@@ -102,19 +102,21 @@ var d3scription = d3scription || {}; d3scription["d3scription"] =
 	                        .style("left", position.left + "px");
 	                });
 	            }
-	            setupTracking(element);
 	            var publicMethods = {
-	                setElement: function (element) {
+	                element: function (element) {
 	                    setupTracking(element);
+	                    return publicMethods;
 	                },
 	                show: function (data) {
 	                    tip.html(contentGetter(data));
 	                    tip.style('visibility', 'visible');
+	                    return publicMethods;
 	                },
 	                hide: function () {
 	                    tip.style('visibility', 'hidden');
+	                    return publicMethods;
 	                },
-	                destroy: function () {
+	                remove: function () {
 	                    tip.remove();
 	                }
 	            };

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,9 +12,12 @@ export interface ContentGetter<T> extends Function {
     (data: T): string;
 }
 export interface Tip<T> {
-    setElement(element: d3.Selection<any>): void;
-    show(data: T): void;
-    hide(): void;
-    destroy(): void;
+    element(element: d3.Selection<any>): Tip<T>;
+    show(data: T): Tip<T>;
+    hide(): Tip<T>;
+    remove(): void;
 }
-export default function d3scription<T>(contentGetter: ContentGetter<T>, options?: Options): (element: d3.Selection<any>) => Tip<T>;
+export interface TipFactory<T> extends Function {
+    (): Tip<T>;
+}
+export default function d3scription<T>(contentGetter: ContentGetter<T>, options?: Options): TipFactory<T>;

--- a/index.ts
+++ b/index.ts
@@ -16,10 +16,14 @@ export interface ContentGetter<T> extends Function {
 }
 
 export interface Tip<T> {
-    setElement(element : d3.Selection<any>) : void;
-    show(data : T) : void;
-    hide() : void;
-    destroy() : void;
+    element(element : d3.Selection<any>) : Tip<T>;
+    show(data : T) : Tip<T>;
+    hide() : Tip<T>;
+    remove() : void;
+}
+
+export interface TipFactory<T> extends Function {
+    () : Tip<T>
 }
 
 interface WindowDimensions {
@@ -65,10 +69,10 @@ function getOffsetSettings(offset? : Offset) : Position {
     };
 }
 
-export default function d3scription<T> (contentGetter : ContentGetter<T>, options:Options = {}) {
+export default function d3scription<T> (contentGetter : ContentGetter<T>, options:Options = {}) : TipFactory<T> {
     const offsetSettings : Position = getOffsetSettings(options.offset);
 
-    return function (element : d3.Selection<any>) : Tip<T> {
+    return function () : Tip<T> {
         const tip : d3.Selection<any> = d3.select('body')
             .append('div')
             .attr('class', options.class || 'd3scription-tip')
@@ -86,20 +90,25 @@ export default function d3scription<T> (contentGetter : ContentGetter<T>, option
                     .style("left", `${position.left}px`);
             });
         }
-        setupTracking(element);
 
         const publicMethods : Tip<T> = {
-            setElement(element : d3.Selection<any>) : void {
+            element(element : d3.Selection<any>) : Tip<T> {
                 setupTracking(element);
+
+                return publicMethods;
             },
-            show(data : T) : void {
+            show(data : T) : Tip<T> {
                 tip.html(contentGetter(data));
                 tip.style('visibility', 'visible');
+
+                return publicMethods;
             },
-            hide() : void {
+            hide() : Tip<T> {
                 tip.style('visibility', 'hidden');
+
+                return publicMethods;
             },
-            destroy() : void {
+            remove() : void {
                 tip.remove();
             }
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3scription",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "D3.js tooltip plugin made simple. With single-page apps in mind. ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Improve API & stable release

I was thinking how about how to even improve this based on real use cases. Previously knowing container element was required for initializing tip instance. I think it do not make much sense. Also all methods was `void`. What I did was to remove `element` parameter from initialization and return  instance in methods. This makes it easy to chain methods if needed. Also there are few other minor changes like `setElement` => `element`.

**previously:**

```js
var tipFactory = d3scription(function(d) { return d.desc; });
var tip = tipFactory(el);
```

**now:**

```js
var tipFactory = d3scription(function(d) { return d.desc; });
var tip = tipFactory()
    .element(el);
```

This makes it easier to wrap tip to another factory etc.