### PR TITLE
Make it compatible with node environment

### DIFF
--- a/dist/d3scription.js
+++ b/dist/d3scription.js
@@ -55,37 +55,56 @@ var d3scription = d3scription || {}; d3scription["d3scription"] =
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/// <reference path="d/d3.d.ts" />
 	!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__, exports], __WEBPACK_AMD_DEFINE_RESULT__ = function (require, exports) {
 	    "use strict";
-	    var windowDimensions = {
-	        width: window.innerWidth,
-	        height: window.innerHeight
-	    };
-	    function setWindowDimmensions() {
-	        windowDimensions = {
-	            width: window.innerWidth,
-	            height: window.innerHeight
-	        };
-	    }
-	    var windowResize = window.addEventListener('resize', setWindowDimmensions);
-	    function getOffset(event, bounds, offset) {
-	        var collideVertically = (windowDimensions.height + window.scrollY) - event.pageY - offset.top - bounds.height < 0;
-	        var collideHorizontally = (windowDimensions.width + window.scrollX) - event.pageX - offset.left - bounds.width < 0;
-	        return {
-	            top: collideVertically ? event.pageY - bounds.height - offset.top : offset.top + event.pageY,
-	            left: collideHorizontally ? event.pageX - bounds.width - offset.left : event.pageX + offset.left
-	        };
-	    }
+	    Object.defineProperty(exports, "__esModule", { value: true });
 	    var defaultOffset = { top: 10, left: 10 };
 	    function getOffsetSettings(offset) {
-	        if (!offset)
+	        if (!offset) {
 	            return defaultOffset;
+	        }
 	        return {
 	            top: offset.top === undefined ? defaultOffset.top : offset.top,
 	            left: offset.left === undefined ? defaultOffset.left : offset.left
 	        };
 	    }
+	    function getDimensions(el) {
+	        return {
+	            width: el.innerWidth,
+	            height: el.innerHeight
+	        };
+	    }
 	    function d3scription(contentGetter, options) {
 	        if (options === void 0) { options = {}; }
+	        if (typeof window === 'undefined') {
+	            return function () {
+	                var methods = {
+	                    element: function (element) {
+	                        return methods;
+	                    },
+	                    show: function (data) {
+	                        return methods;
+	                    },
+	                    hide: function () {
+	                        return methods;
+	                    },
+	                    remove: function () { }
+	                };
+	                return methods;
+	            };
+	        }
 	        var offsetSettings = getOffsetSettings(options.offset);
+	        var windowDimensions = getDimensions(window);
+	        function getOffset(event, bounds, offset) {
+	            var collideVertically = (windowDimensions.height + window.scrollY) - event.pageY - offset.top - bounds.height < 0;
+	            var collideHorizontally = (windowDimensions.width + window.scrollX) - event.pageX - offset.left - bounds.width < 0;
+	            return {
+	                top: collideVertically ? event.pageY - bounds.height - offset.top : offset.top + event.pageY,
+	                left: collideHorizontally ? event.pageX - bounds.width - offset.left : event.pageX + offset.left
+	            };
+	        }
+	        function setWindowDimmensions() {
+	            windowDimensions = getDimensions(window);
+	        }
+	        var windowResize = window.addEventListener('resize', setWindowDimmensions);
 	        return function () {
 	            var tip = d3.select('body')
 	                .append('div')
@@ -98,8 +117,8 @@ var d3scription = d3scription || {}; d3scription["d3scription"] =
 	                    var bounds = tip.node().getBoundingClientRect();
 	                    var position = getOffset(d3.event, bounds, offsetSettings);
 	                    tip
-	                        .style("top", position.top + "px")
-	                        .style("left", position.left + "px");
+	                        .style('top', position.top + "px")
+	                        .style('left', position.left + "px");
 	                });
 	            }
 	            var publicMethods = {
@@ -123,7 +142,6 @@ var d3scription = d3scription || {}; d3scription["d3scription"] =
 	            return publicMethods;
 	        };
 	    }
-	    Object.defineProperty(exports, "__esModule", { value: true });
 	    exports.default = d3scription;
 	    // export as Global Object
 	    if (typeof window === 'object') {

--- a/index.ts
+++ b/index.ts
@@ -1,114 +1,134 @@
 /// <reference path="d/d3.d.ts" />
 
 export interface Offset {
-    top? : number;
-    left? : number;
+    top?: number;
+    left?: number;
 }
 
 export interface Options {
-    zIndex? : number;
-    class? : string;
-    offset? : Offset;
+    zIndex?: number;
+    class?: string;
+    offset?: Offset;
 }
 
 export interface ContentGetter<T> extends Function {
-    (data : T) : string;
+    (data: T): string;
 }
 
 export interface Tip<T> {
-    element(element : d3.Selection<any>) : Tip<T>;
-    show(data : T) : Tip<T>;
-    hide() : Tip<T>;
-    remove() : void;
+    element(element: d3.Selection<any>): Tip<T>;
+    show(data: T): Tip<T>;
+    hide(): Tip<T>;
+    remove(): void;
 }
 
 export interface TipFactory<T> extends Function {
-    () : Tip<T>
+    (): Tip<T>;
 }
 
-interface WindowDimensions {
-    width : number,
-    height : number
+interface Dimensions {
+    width: number;
+    height: number;
 }
 
 interface Position {
-    top : number,
-    left : number,
+    top: number,
+    left: number,
 }
 
-let windowDimensions : WindowDimensions = {
-    width: window.innerWidth,
-    height: window.innerHeight
-}
+const defaultOffset: Position = { top: 10, left: 10 };
+function getOffsetSettings(offset ?: Offset): Position {
+    if (!offset) { return defaultOffset; }
 
-function setWindowDimmensions() : void {
-    windowDimensions = {
-        width: window.innerWidth,
-        height: window.innerHeight
-    }
-}
-
-const windowResize = window.addEventListener('resize', setWindowDimmensions);
-
-function getOffset(event : MouseEvent, bounds : ClientRect, offset : Position) : Position {
-    const collideVertically : boolean = (windowDimensions.height + window.scrollY) - event.pageY - offset.top - bounds.height < 0;
-    const collideHorizontally : boolean = (windowDimensions.width + window.scrollX) - event.pageX - offset.left - bounds.width < 0;
-
-    return {
-        top: collideVertically ? event.pageY - bounds.height - offset.top : offset.top + event.pageY,
-        left: collideHorizontally ? event.pageX - bounds.width - offset.left : event.pageX + offset.left
-    };
-}
-
-const defaultOffset : Position = { top: 10, left: 10 };
-function getOffsetSettings(offset? : Offset) : Position {
-    if (!offset) return defaultOffset;
     return {
         top: offset.top === undefined ? defaultOffset.top : offset.top,
         left: offset.left === undefined ? defaultOffset.left : offset.left
     };
 }
 
-export default function d3scription<T> (contentGetter : ContentGetter<T>, options:Options = {}) : TipFactory<T> {
-    const offsetSettings : Position = getOffsetSettings(options.offset);
+function getDimensions(el): Dimensions {
+    return {
+        width: el.innerWidth,
+        height: el.innerHeight
+    };
+}
 
-    return function () : Tip<T> {
-        const tip : d3.Selection<any> = d3.select('body')
+export default function d3scription<T> (contentGetter: ContentGetter<T>, options: Options = {}): TipFactory<T> {
+    if (typeof window === 'undefined') {
+        return (): Tip<T> => {
+            const methods = {
+                element(element: d3.Selection<any>): Tip<T> {
+                    return methods;
+                },
+                show(data: T): Tip<T> {
+                    return methods;
+                },
+                hide(): Tip<T> {
+                    return methods;
+                },
+                remove(): void {}
+            };
+
+            return methods;
+        };
+    }
+
+    const offsetSettings: Position = getOffsetSettings(options.offset);
+    let windowDimensions: Dimensions = getDimensions(window);
+
+    function getOffset(event: MouseEvent, bounds: ClientRect, offset: Position): Position {
+        const collideVertically: boolean = (windowDimensions.height + window.scrollY) - event.pageY - offset.top - bounds.height < 0;
+        const collideHorizontally: boolean = (windowDimensions.width + window.scrollX) - event.pageX - offset.left - bounds.width < 0;
+
+        return {
+            top: collideVertically ? event.pageY - bounds.height - offset.top : offset.top + event.pageY,
+            left: collideHorizontally ? event.pageX - bounds.width - offset.left : event.pageX + offset.left
+        };
+    }
+
+    function setWindowDimmensions() {
+        windowDimensions = getDimensions(window);
+    }
+
+    const windowResize = window.addEventListener('resize', setWindowDimmensions);
+
+    return function (): Tip<T> {
+        const tip: d3.Selection<any> = d3.select('body')
             .append('div')
             .attr('class', options.class || 'd3scription-tip')
             .style('position', 'absolute')
             .style('z-index', options.zIndex || 100)
             .style('visibility', 'hidden');
 
-        function setupTracking(element : d3.Selection<any>) : void {
-            element.on('mousemove', () : void => {
-                const bounds : ClientRect = tip.node().getBoundingClientRect();
-                const position : Position = getOffset(d3.event, bounds, offsetSettings)
+        function setupTracking(element: d3.Selection<any>): void {
+            element.on('mousemove', (): void => {
+                const bounds: ClientRect = tip.node().getBoundingClientRect();
+                const position: Position = getOffset(d3.event, bounds, offsetSettings);
 
                 tip
-                    .style("top", `${position.top}px`)
-                    .style("left", `${position.left}px`);
+                    .style('top', `${position.top}px`)
+                    .style('left', `${position.left}px`);
             });
         }
 
-        const publicMethods : Tip<T> = {
-            element(element : d3.Selection<any>) : Tip<T> {
+        const publicMethods: Tip<T> = {
+            element(element: d3.Selection<any>): Tip<T> {
                 setupTracking(element);
 
                 return publicMethods;
             },
-            show(data : T) : Tip<T> {
+            show(data: T): Tip<T> {
                 tip.html(contentGetter(data));
                 tip.style('visibility', 'visible');
 
                 return publicMethods;
             },
-            hide() : Tip<T> {
+            hide(): Tip<T> {
                 tip.style('visibility', 'hidden');
 
                 return publicMethods;
             },
-            remove() : void {
+            remove(): void {
                 tip.remove();
             }
         };


### PR DESCRIPTION
Currently when rendering charts that uses this plugin on server side (node) - there are errors that window is not defined - which is perfectly understandable.

This PR fixes that by returning dump interface without ever interacting with window if it's not defined.